### PR TITLE
Small rules moving out of mixins

### DIFF
--- a/_buttons.scss
+++ b/_buttons.scss
@@ -139,15 +139,10 @@ category: Common
 */
 
 @mixin button-height($button-size) {
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     height: $button-size;
     padding: 0 ($button-size / 3);
     margin-right: $button-size / 3;
     line-height: $button-size + 2px;
-    border-width: 1px;
-    border-style: solid;
     
     .i {
         width: $button-size;
@@ -156,13 +151,9 @@ category: Common
     }
     .i-left {
         margin-left: -($button-size / 3);
-        margin-right: 0;
-        float: left;
     }
     .i-right {
         margin-right: -($button-size / 3);
-        margin-left: 0;
-        float: right;
     }
 }
 @mixin button-colour($fill-colour, $text-colour, $hover-colour, $hover-border: $hover-colour) {
@@ -181,20 +172,36 @@ category: Common
     display: inline-block;
     vertical-align: top;
     width: auto;
-    @include fs-textSans(2);
     font-weight: bold;
     text-decoration: none;
-    @include button-height($gs-baseline * 2.5);
+
     // If we want to draw a circle, output a pixel value instead,
     // as older versions of WebKit do not support % in border-radius
     -webkit-border-radius: 1000px;
     border-radius: 1000px;
+    border-width: 1px;
+    border-style: solid;
+
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+
+    @include fs-textSans(2);
+    @include button-height($gs-baseline * 2.5);
     @include button-colour(guss-colour(tone-news-2, $pasteup-palette), #ffffff, guss-colour(tone-news-1, $pasteup-palette));
 
     &:hover,
     &:focus,
     &:active {
         text-decoration: none;
+    }
+    .i-left {
+        margin-right: 0;
+        float: left;
+    }
+    .i-right {
+        margin-left: 0;
+        float: right;
     }
 }
 .button--primary {


### PR DESCRIPTION
Moved those small bits out of the mixins.

I saw that you guys are not a big fans of blank lines. I actually like them because I believe it's increasing readability but I am happy to move to whatever style you are using to keep consistency. But I've noticed that it varies a lot across the files. Maybe it will be nice to put down some basic rules (CSS guidelines) to unify the style we are writing CSS. If we don't have something like that already. 
