### PR TITLE
Put button modifications behind the if statements

### DIFF
--- a/src/_buttons.scss
+++ b/src/_buttons.scss
@@ -58,6 +58,28 @@ Show more button:
 
 @import 'mixins';
 
+$pasteup-button-primary: false !default;
+$pasteup-button-secondary: false !default;
+$pasteup-button-tertiary: false !default;
+$pasteup-button-tone-media: false !default;
+$pasteup-button-tone-media-variant: false !default;
+$pasteup-button-tone-news: false !default;
+$pasteup-button-tone-news-variant: false !default;
+$pasteup-button-tone-feature: false !default;
+$pasteup-button-tone-feature-variant: false !default;
+$pasteup-button-tone-comment: false !default;
+$pasteup-button-tone-comment-variant: false !default;
+$pasteup-button-tone-live: false !default;
+$pasteup-button-tone-live-variant: false !default;
+
+$pasteup-button-xlarge: false !default;
+$pasteup-button-large: false !default;
+$pasteup-button-medium: false !default;
+$pasteup-button-small: false !default;
+$pasteup-button-xsmall: false !default;
+
+$pasteup-button-show-more: false !default;
+
 /*
     If we want to draw a circle, output a pixel value instead,
     as older versions of WebKit do not support % in border-radius
@@ -98,154 +120,215 @@ Show more button:
         float: right;
     }
 }
-.button--primary {
-    @include button-colour(
-        guss-colour(guardian-brand, $pasteup-palette),
-        #ffffff,
-        darken(guss-colour(guardian-brand, $pasteup-palette), 10%)
-    );
-}
-.button--secondary {
-    @include button-colour(
-        guss-colour(neutral-7, $pasteup-palette),
-        guss-colour(neutral-1, $pasteup-palette),
-        darken(guss-colour(neutral-7, $pasteup-palette), 10%)
-    );
-}
-.button--tertiary {
-    @include button-colour(
-        transparent,
-        guss-colour(neutral-1, $pasteup-palette),
-        transparent,
-        darken(guss-colour(neutral-3, $pasteup-palette), 10%),
-        guss-colour(neutral-4, $pasteup-palette)
-    );
-}
-.button--tone-media {
-    @include button-colour(
-        guss-colour(multimedia-support-4, $pasteup-palette),
-        #ffffff,
-        guss-colour(neutral-2, $pasteup-palette)
-    );
-}
-.button--tone-media-variant {
-    @include button-colour(
-        guss-colour(multimedia-main-1, $pasteup-palette),
-        #ffffff,
-        guss-colour(multimedia-main-1, $pasteup-palette),
-        guss-colour(neutral-3, $pasteup-palette),
-        guss-colour(neutral-2, $pasteup-palette)
-    );
-}
-.button--tone-news {
-    @include button-colour(
-        guss-colour(neutral-7, $pasteup-palette),
-        guss-colour(news-main-1, $pasteup-palette),
-        darken(guss-colour(neutral-7, $pasteup-palette), 10%)
-    );
-}
-.button--tone-news-variant {
-    @include button-colour(
-        #ffffff,
-        guss-colour(news-main-1, $pasteup-palette),
-        #ffffff,
-        darken(guss-colour(neutral-3, $pasteup-palette), 10%),
-        guss-colour(neutral-4, $pasteup-palette)
-    );
-}
-.button--tone-feature {
-    @include button-colour(
-        guss-colour(neutral-7, $pasteup-palette),
-        guss-colour(features-support-1, $pasteup-palette),
-        darken(guss-colour(neutral-7, $pasteup-palette), 10%)
-    );
-}
-.button--tone-feature-variant {
-    @include button-colour(
-        #ffffff,
-        guss-colour(features-support-1, $pasteup-palette),
-        #ffffff,
-        darken(guss-colour(neutral-3, $pasteup-palette), 10%),
-        guss-colour(neutral-4, $pasteup-palette)
-    );
-}
-.button--tone-comment {
-    @include button-colour(
-        guss-colour(neutral-7, $pasteup-palette),
-        guss-colour(comment-main-1, $pasteup-palette),
-        darken(guss-colour(neutral-7, $pasteup-palette), 10%)
-    );
-}
-.button--tone-comment-variant {
-    @include button-colour(
-        #ffffff,
-        guss-colour(comment-main-1, $pasteup-palette),
-        #ffffff,
-        darken(guss-colour(neutral-3, $pasteup-palette), 10%),
-        guss-colour(neutral-4, $pasteup-palette)
-    );
-}
-.button--tone-live {
-    @include button-colour(
-        guss-colour(neutral-6, $pasteup-palette),
-        guss-colour(neutral-1, $pasteup-palette),
-        darken(guss-colour(neutral-6, $pasteup-palette), 10%)
-    );
-}
-.button--tone-live-variant {
-    @include button-colour(
-        guss-colour(neutral-8, $pasteup-palette),
-        guss-colour(neutral-1, $pasteup-palette),
-        guss-colour(neutral-8, $pasteup-palette),
-        darken(guss-colour(neutral-3, $pasteup-palette), 10%),
-        guss-colour(neutral-3, $pasteup-palette)
-    );
-}
-.button--xlarge {
-    @include button-height(44px);
-}
-.button--large {
-    @include button-height($base-size * 6);
 
-    @include mq($from: desktop) {
-        line-height: ($base-size * 6) + 2;
+@if ($pasteup-button-primary == true) {
+    .button--primary {
+        @include button-colour(
+            guss-colour(guardian-brand, $pasteup-palette),
+            #ffffff,
+            darken(guss-colour(guardian-brand, $pasteup-palette), 10%)
+        );
     }
 }
-.button--medium {
-    @include button-height($base-size * 5);
 
-    @include mq($from: desktop) {
-        line-height: ($base-size * 5) + 2px;
+@if ($pasteup-button-secondary == true) {
+    .button--secondary {
+        @include button-colour(
+            guss-colour(neutral-7, $pasteup-palette),
+            guss-colour(neutral-1, $pasteup-palette),
+            darken(guss-colour(neutral-7, $pasteup-palette), 10%)
+        );
     }
 }
-.button--small {
-    @include button-height($base-size * 4);
-    @include fs-textSans(1);
-    line-height: $gs-baseline * 2 - 2px;
-    font-weight: bold;
+
+@if ($pasteup-button-tertiary == true) {
+    .button--tertiary {
+        @include button-colour(
+            transparent,
+            guss-colour(neutral-1, $pasteup-palette),
+            transparent,
+            darken(guss-colour(neutral-3, $pasteup-palette), 10%),
+            guss-colour(neutral-4, $pasteup-palette)
+        );
+    }
 }
-.button--xsmall {
-    @include button-height($base-size * 3);
-    @include fs-textSans(1);
-    line-height: ($base-size * 3) - 2px;
-    font-weight: bold;
+
+@if ($pasteup-button-tone-media == true) {
+    .button--tone-media {
+        @include button-colour(
+            guss-colour(multimedia-support-4, $pasteup-palette),
+            #ffffff,
+            guss-colour(neutral-2, $pasteup-palette)
+        );
+    }
 }
 
-$show-more-icon-size: $base-size * 4;
-$show-more-icon-spacing: $base-size + 1;
+@if ($pasteup-button-tone-media-variant == true) {
+    .button--tone-media-variant {
+        @include button-colour(
+            guss-colour(multimedia-main-1, $pasteup-palette),
+            #ffffff,
+            guss-colour(multimedia-main-1, $pasteup-palette),
+            guss-colour(neutral-3, $pasteup-palette),
+            guss-colour(neutral-2, $pasteup-palette)
+        );
+    }
+}
 
-.button--show-more {
-    position: relative;
-    padding-left: $show-more-icon-size + $show-more-icon-spacing * 2;
+@if ($pasteup-button-tone-news == true) {
+    .button--tone-news {
+        @include button-colour(
+            guss-colour(neutral-7, $pasteup-palette),
+            guss-colour(news-main-1, $pasteup-palette),
+            darken(guss-colour(neutral-7, $pasteup-palette), 10%)
+        );
+    }
+}
 
-    .i {
-        width: $show-more-icon-size;
-        height: $show-more-icon-size;
-        vertical-align: middle;
-        margin: auto;
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: $show-more-icon-spacing;
+@if ($pasteup-button-tone-news-variant == true) {
+    .button--tone-news-variant {
+        @include button-colour(
+            #ffffff,
+            guss-colour(news-main-1, $pasteup-palette),
+            #ffffff,
+            darken(guss-colour(neutral-3, $pasteup-palette), 10%),
+            guss-colour(neutral-4, $pasteup-palette)
+        );
+    }
+}
+
+@if ($pasteup-button-tone-feature == true) {
+    .button--tone-feature {
+        @include button-colour(
+            guss-colour(neutral-7, $pasteup-palette),
+            guss-colour(features-support-1, $pasteup-palette),
+            darken(guss-colour(neutral-7, $pasteup-palette), 10%)
+        );
+    }
+}
+
+@if ($pasteup-button-tone-feature-variant == true) {
+    .button--tone-feature-variant {
+        @include button-colour(
+            #ffffff,
+            guss-colour(features-support-1, $pasteup-palette),
+            #ffffff,
+            darken(guss-colour(neutral-3, $pasteup-palette), 10%),
+            guss-colour(neutral-4, $pasteup-palette)
+        );
+    }
+}
+
+@if ($pasteup-button-tone-comment == true) {
+    .button--tone-comment {
+        @include button-colour(
+            guss-colour(neutral-7, $pasteup-palette),
+            guss-colour(comment-main-1, $pasteup-palette),
+            darken(guss-colour(neutral-7, $pasteup-palette), 10%)
+        );
+    }
+}
+
+@if ($pasteup-button-tone-comment-variant == true) {
+    .button--tone-comment-variant {
+        @include button-colour(
+            #ffffff,
+            guss-colour(comment-main-1, $pasteup-palette),
+            #ffffff,
+            darken(guss-colour(neutral-3, $pasteup-palette), 10%),
+            guss-colour(neutral-4, $pasteup-palette)
+        );
+    }
+}
+
+@if ($pasteup-button-tone-live == true) {
+    .button--tone-live {
+        @include button-colour(
+            guss-colour(neutral-6, $pasteup-palette),
+            guss-colour(neutral-1, $pasteup-palette),
+            darken(guss-colour(neutral-6, $pasteup-palette), 10%)
+        );
+    }
+}
+
+@if ($pasteup-button-tone-live-variant == true) {
+    .button--tone-live-variant {
+        @include button-colour(
+            guss-colour(neutral-8, $pasteup-palette),
+            guss-colour(neutral-1, $pasteup-palette),
+            guss-colour(neutral-8, $pasteup-palette),
+            darken(guss-colour(neutral-3, $pasteup-palette), 10%),
+            guss-colour(neutral-3, $pasteup-palette)
+        );
+    }
+}
+
+@if ($pasteup-button-xlarge == true) {
+    .button--xlarge {
+        @include button-height(44px);
+    }
+}
+
+@if ($pasteup-button-large == true) {
+    .button--large {
+        @include button-height($base-size * 6);
+
+        @include mq($from: desktop) {
+            line-height: ($base-size * 6) + 2;
+        }
+    }
+}
+
+@if ($pasteup-button-medium == true) {
+    .button--medium {
+        @include button-height($base-size * 5);
+
+        @include mq($from: desktop) {
+            line-height: ($base-size * 5) + 2px;
+        }
+    }
+}
+
+@if ($pasteup-button-small == true) {
+    .button--small {
+        @include button-height($base-size * 4);
+        @include fs-textSans(1);
+        line-height: $gs-baseline * 2 - 2px;
+        font-weight: bold;
+    }
+}
+
+@if ($pasteup-button-xsmall == true) {
+    .button--xsmall {
+        @include button-height($base-size * 3);
+        @include fs-textSans(1);
+        line-height: ($base-size * 3) - 2px;
+        font-weight: bold;
+    }
+}
+
+
+@if ($pasteup-button-show-more == true) {
+    $show-more-icon-size: $base-size * 4;
+    $show-more-icon-spacing: $base-size + 1;
+
+    .button--show-more {
+        position: relative;
+        padding-left: $show-more-icon-size + $show-more-icon-spacing * 2;
+
+        .i {
+            width: $show-more-icon-size;
+            height: $show-more-icon-size;
+            vertical-align: middle;
+            margin: auto;
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: $show-more-icon-spacing;
+        }
+
+        .js-off & {
+            display: none;
+        }
     }
 }


### PR DESCRIPTION
We are not using all the buttons on theguardian.com and if some other teams are using this lib they might want not to use some modifications.

This PR is putting all modifications of buttons behind the IFs with the variables set to false as default.

It will require to add some sort of settings to the projects which will change some of this defaults to true. It won't make massive difference (on theguardian.com it is saving 0.22KB gzipped) but it will make this objects library more adaptable.

CC @sndrs @austinh7 I will probably bump the version to 0.5.0