### PR TITLE
Add implicit sizing for inlined svg element

### DIFF
--- a/src/_mixins.scss
+++ b/src/_mixins.scss
@@ -15,6 +15,12 @@ $base-size: $gs-baseline / 2;
         height: $button-size;
         margin: -1px (-$button-size / 3) 0;
     }
+
+    svg {
+        width: $button-size;
+        height: $button-size;
+    }
+
     .i-left {
         margin-left: -($button-size / 3);
         margin-right: 0;


### PR DESCRIPTION
Now that we are porting most of our icons on theguardian.com from being background images defined on `<i class="i i-right" />` elements to being inlined `<svg>` icons within the document. We need to implicitly style the icons within the button mixin here to that they are sized appropriately to the button and not the default dimensions on the svg;s `width` and `height` attributes. 

(not: this relies on the svg having a `viewBox` attribute defined)

/cc @sndrs @uplne @austinh7 